### PR TITLE
Fix Initial redirect & fixed ability for production command to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript-project",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=production node server/server.js",
+    "start": "node server/server.js",
     "build": "webpack --mode production",
     "dev": "nodemon server/server.js & NODE_ENV=development webpack serve --open --hot",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript-project",
   "main": "index.js",
   "scripts": {
-    "start": "node server/server.js",
+    "start": "NODE_ENV=production node server/server.js",
     "build": "webpack --mode production",
     "dev": "nodemon server/server.js & NODE_ENV=development webpack serve --open --hot",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,10 @@
-import React from "react";
+import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import MainContainer from "./containers/MainContainer";
-import UserProfileContainer from "./containers/UserProfileContainer";
-import DependentContainer from "./containers/DependentContainer";
-import AddNewComponent from "./components/AddNewComponent";
-
-
+import MainContainer from './containers/MainContainer';
+import UserProfileContainer from './containers/UserProfileContainer';
+import DependentContainer from './containers/DependentContainer';
+import AddNewComponent from './components/AddNewComponent';
 
 const App = () => {
   return (
@@ -15,20 +13,18 @@ const App = () => {
       <p>This is Reem</p>
       <p>Hello Guys Bongi</p> */}
       <main>
-      <MainContainer/>
+        <MainContainer />
 
         <Routes>
-          <Route path = 'user' element ={<UserProfileContainer/>} />
-          <Route path = 'dependent/:id' element={<DependentContainer/>}/>
-          <Route path = 'addnew' element={<AddNewComponent/>}/>
+          <Route path="/" element={<UserProfileContainer />} />
+          <Route path="user" element={<UserProfileContainer />} />
+          <Route path="dependent/:id" element={<DependentContainer />} />
+          <Route path="addnew" element={<AddNewComponent />} />
         </Routes>
 
-
-
-      {/* </MainContainer> */}
+        {/* </MainContainer> */}
       </main>
     </div>
-    
   );
 };
 


### PR DESCRIPTION
This PR has two changes:

1. **Adjusted initial redirect so we don't have a blank homepage**
Fixed this by editing `src/App.jsx` to include one additional route to root path `/` which renders the same `UserProfileContainer` as the `user` path. This approach preserves backwards compatibility of any links to `/user`. I also ran formatting adjustments on the `src/App.jsx` file.

2. **Fixed ability to run production build**
I noticed that when running the commands:
```
npm run build
npm run start
```
The initial webpage failed to load. I attempted to explicitly specify a mode in the `package.json` commands and that appears to have fixed.
